### PR TITLE
Updates circles.yml to include correct CIT title

### DIFF
--- a/_data/circles.yml
+++ b/_data/circles.yml
@@ -8,7 +8,7 @@
   icon: 'map-marker'
   img: '/assets/img/privacy-slide.png'
   description: 'Learn about digital privacy tools in this new METRO course.'
-- title: Digitization Toolkit
+- title: Culture in Transit Toolkit
   url: 'http://metro.org/cit-toolkit'
   icon: 'calendar'
   img: '/assets/img/slide-one.png'


### PR DESCRIPTION
Resolves #46 

# What does this Pull Request do?

Changes a title on metro's homepage cycling banners. Makes `Culture in Transit Toolkit` the title for http://metro.org/cit-toolkit Website's banner in our homepage carousel

# What's new?
Correct title for a very much loved metro project.

# Additional Notes:
Based on a @kerriwillette's request

# Interested parties
@jmignault 