### PR TITLE
Replaced Imaging services with studio services

### DIFF
--- a/pages/services/digital-services.md
+++ b/pages/services/digital-services.md
@@ -6,7 +6,7 @@ permalink: /services/digital-services
 
 [Data Services](#esdn)
 
-[Imaging and Digitization Services](#cit)
+[Studio Services](#cit)
 
 [Digitization Grant Program](#digi_grants)
 
@@ -33,12 +33,77 @@ METRO aggregates descriptive metadata from hundreds of libraries, archives, muse
 
 [Back to top](#top)
 
-## <a class="anchor" name="cit"></a>Imaging and Digitization Services
-While libraries, archives, and partners such as Internet Archive and Google have digitized and made billions of resources available online over the past decades, there is still a long trail of documents, newsletters, photographs, and other materials in the hands of smaller institutions and community members that are in effect invisible because they are not yet available online.
+## <a class="anchor" name="cit"></a>599 Studio
+In March of 2017, we opened our new 8,000 square foot studio called 599 on the west side of midtown Manhattan. 599 is an architectural and programmatic instantiation of a digital library in physical space: we offer tools and resources that empower our members to read, write, and participate on the web. More specifically, our activities are focused on the digitization, description, and presentation of cultural heritage materials. 599 makes the labor and the communities associated with archiving and preservation visible, legible, and accessible; the space itself is a platform for action so that participants can organize to create their own community narratives. 
 
-Concluding its first iteration in October 2016, [Culture in Transit](http://www.mnylc.org/cit/) (CIT), a project of METRO in partnership with Queens Library and Brooklyn Public Library, addressed this issue by taking shared digitization technologies and expertise to libraries, archives, and communities throughout the metropolitan New York area to digitize and share the city’s rich cultural heritage online with the world. This project culminated in a [comprehensive toolkit.](https://mnylc.github.io/cit-toolkit/)
+599 is launching with five service points: a digital forensics station, a born-digital workstation, an imaging station, a recording station, an audio / video transfer station, and a graphic output / print station. We’ll be adding more specifics about our equipment and its availability here soon, so stay in touch!
 
-CIT was funded by the John S. and James L. Knight Foundation, as part of their Knight News Challenge on Libraries.
+## Born-digital Workstation
+
+The born-digital workstation is a Windows 7 (64-bit) CPU with a 3.7 GHz Intel Xeon processor, 32 GB RAM, and a 2TB SATA hard drive. It comes equipped with [BitCurator](https://www.bitcurator.net/), an open-source suite of digital forensics tools, and [ePADD](http://epadd.stanford.edu/epadd/collections), an open-source software package that supports archival processes around the appraisal, ingest, processing, discovery, and delivery of email archives. The following legacy media drives are available to recover archival data:
+
+3.5” floppy disk drive
+5.25” floppy disk drive
+Zip disk drive
+Multimedia and memory cards (found in digital Cameras, MP3 Players, VoiceRecorders, etc.)
+
+## Digital Forensics Workstation
+
+The [Forensic Recovery of Evidence Device](https://www.digitalintelligence.com/products/fred/) (FRED) securely acquires data directly from IDE/EIDE/ATA/SATA/ATAPI/SAS/Firewire/USB hard drives and storage devices, as well as Blu-Ray, CD-ROM, DVD-ROM, Compact Flash, Micro Drives, Smart Media, Memory Stick, Memory Stick Pro, xD Cards, Secure Digital Media and Multimedia Cards. FRED uses FTK Imager and EnCase for analyzing and processing forensic disk captures.
+
+Both the Born-digital and the Digital Forensics workstations come equipped with hardware write blockers: IDE/SATA/SAS/USB 3.0/2.0/Firewire IEEE 1394b, PCIe.
+
+## Imaging Station
+
+### Flatbed Scanning 
+[The Epson Perfection V600 Photo Scanner](https://epson.com/For-Home/Scanners/Photo/Epson-Perfection-V600-Photo-Scanner/p/B11B198011) and [Epson Expression 11000XL Photo Scanner](https://epson.com/For-Work/Scanners/Photo-and-Graphics/Epson-Expression-11000XL--Photo-Scanner/p/E11000XL-PH)
+create preservation grade image files of archival and library material with our state of the art flatbed scanners.
+
+The Epson V600 is a scanning solution for medium format material up to 8.5 x 11.7", with a maximum resolution of 6400 x 9600 dpi. Our Epson 11000XL features a 2400 x 4800 dpi optical resolution and a 48-bit color depth. The scanner can handle original material as large as 12.0 x 17.0". 
+
+The scanners allow you the ability to digitize a range of archival material, including photographs, manuscript material, documents, pamphlets and newsletters. 
+
+Both scanners also boast the capability to digitize a range of transmissive material and come with a range of transparency units for film scanning. The V600 allows scanning of four 35mm mounted slides, or 12 negatives and it handles medium format film up to 6 x 22cm. The 11000XL features 4 film holders for an easy way to scan 35mm negatives, mounted slides, 120 and 220 medium format transparencies, and 4.0 x 5.0" film. Additionally the transparency unit can be used without film holders to scan non-standard sizes as large as 12.2 x 16.5".
+
+Equipped with Epson’s Silverfast imaging software for better color management and more granular setting options than the built-in Epson software, our flatbed scanning solutions mean you can produce preservation quality image files, with the ability to create access derivatives at our post processing station.
+
+
+### Object Digitization
+[Canon EOS Rebel T5 DSLR Camera](https://www.bhphotovideo.com/c/product/1030209-REG/canon_9126b003_eos_a_rebel_t5_dslr.html) with Macro Lens
+Our Canon EF-S 60mm f/2.8 Macro USM Lens is perfect for object digitization. Have a collection of pin badges, campaign ribbons or medals? Using our tripod and Canon camera with macro lens, you can create high quality, detailed images of small objects in your collection.
+
+Using the macro lens coupled with our [Porta-Trace 10 x 12" LED lightbox](https://www.amazon.com/Porta-Trace-12-inches-Stainless-Lightbox/dp/B0002GRL9U), you also have the capability to digitize a set of lantern slides or oversize glass plate negatives that do not fit on our flatbed scanners. Using Photoshop at our post processing station to invert the negatives to positives, you will have a set of web ready images to expand access to your collections. 
+
+### Image Post Processing
+[Adobe Creative Cloud](http://www.adobe.com/creativecloud.html)
+Software for post-processing of images. Batch edit with Adobe Bridge or Photoshop, create a range of derivatives to suit your needs or work on individual images to crop, resize or manage color and tone. 
+
+## Graphic Output / Print Station
+
+We have a [Graphtec CE6000 vinyl plotter](http://www.graphtecamerica.com/graphtec-america-products-cutting-plotters-ce6000-4060120-professional-performance) that is available for our members to make high quality, professional decals for exhibits, displays, and countless other uses. Because this is a new service, we have a limited supply of vinyl in 10 different colors that we can make available to you for free. Moving forward, vinyl will be available for a fee, or you can bring your own material as long as it fits the correct specifications for this machine.
+
+[Software requirements and tutorial videos](/vinyl).
+
+## Audio Recording
+
+Our [5 x 7 foot VocalBooth Recording Studio and Sound Isolation Booth](http://www.vocalbooth.com/)
+is a stand-alone, pop-up recording studio that filters out outside noise and improves sound quality of recordings. Equipped with a ventilation, outlets, lighting, cable ports, and foam wrapped walls. It is perfect for recording podcasts, voice-overs, and oral histories. 
+
+[3 Blue Yeti Microphones](http://www.bluemic.com/products/yeti/)
+Studio-quality USB microphones, outfitted with pop filters and suspension arms to soften those "p-pops" and table noises.
+
+[Izotope RX Plugin](https://www.izotope.com/en/products/repair-and-edit/rx-plug-in-pack.html)
+Software for post-production audio cleaning. De-noising, de-humming, de-clicking ...
+
+[Reaper](http://www.reaper.fm/)
+Audio recording, editing, and mixing software.
+
+[Yamaha HS5 speakers](https://usa.yamaha.com/products/proaudio/speakers/hs_series/index.html)
+Industry standard stereo speakers that let you play back your recordings and mixes on an ideal sonic platform.
+
+[ARTcessories HeadAmp 4](http://artproaudio.com/headphone_amps/product/headamp_4/) 
+Head amp for 4 sets of headphones.
+
 
 [Back to top](#top)
 


### PR DESCRIPTION
Replaced "Imaging and Digitization" services with "studio" services to more accurately reflect the breadth of digital services we offer at METRO.

# What does this Pull Request do?

This will delete the previous imaging and digitization services with the studio services so that the studio is more discoverable and the information is more current. 

# What's new?
Added:  studio services 
Removed: imaging and digitization services


# How should this be tested?

no need to test


# Additional Notes:
none

# Interested parties
@jmignault 
